### PR TITLE
Added a solution for Asset bundle manifest is invalid

### DIFF
--- a/docs/custom_server.md
+++ b/docs/custom_server.md
@@ -98,6 +98,10 @@ Now you navigate to `Workbench > Workshop Member Area > Publish project` and the
 - `Description` -> Full description shown on the mod detail page. This would be one possible way **to correctly give credits** for using the Everon Life framework, by including something like `Powered by` or `Built with` `Everon Life Framework` 
 Now click `Bundle` and then `Publish`
 
+If you get: `Asset bundle manifest is invalid` as error when publishing.
+It could be because of some characters that are not supoortet in the workshop.
+Make sure Summary and Description doesn't contain any illegal characters!
+
 
 ### Setting up your server
 Before setting up your server you need two pieces of information: Your mod GUID and the path of your mission config.  


### PR DESCRIPTION
So I just had the problem that I couldn't publish my project because of this error.
After 5 minutes of trying I found out it was because my Description contained illegal characters from copy & pasting 
the "Built with Everon Life Framework" text into it