### PR TITLE
Add ObjectManager for entity spawn with invokeable event

### DIFF
--- a/src/Scripts/Game/Core/EL_ObjectManager.c
+++ b/src/Scripts/Game/Core/EL_ObjectManager.c
@@ -1,0 +1,41 @@
+class EL_ObjectManager
+{
+	//Subscribe to object creation events triggered by game mode logic
+	static const ref ScriptInvoker Event_OnEntityCreated = new ScriptInvoker;
+
+	static IEntity SpawnEntity(typename typeName, BaseWorld world = null, EntitySpawnParams params = null)
+	{
+		IEntity entity = GetGame().SpawnEntity(typeName, world, params);
+		
+		if(entity)
+		{
+			Event_OnEntityCreated.Invoke(entity);
+		}
+		
+		return entity;
+	}
+
+	static IEntity SpawnEntityPrefab(notnull Resource templateResource, BaseWorld world = null, EntitySpawnParams params = null)
+	{
+		IEntity entity = GetGame().SpawnEntityPrefab(templateResource, world, params);
+		
+		if(entity)
+		{
+			Event_OnEntityCreated.Invoke(entity);
+		}
+		
+		return entity;
+	}
+
+    static IEntity SpawnEntityPrefabLocal(notnull Resource templateResource, BaseWorld world = null, EntitySpawnParams params = null)
+	{
+		IEntity entity = GetGame().SpawnEntityPrefabLocal(templateResource, world, params);
+		
+		if(entity)
+		{
+			Event_OnEntityCreated.Invoke(entity);
+		}
+		
+		return entity;
+	}
+};


### PR DESCRIPTION
### Summarize your proposal
Adding a manager class for object creation so the process becomes an invokable event.
It wraps the function API for
- SpawnEntity
- SpawnEntityPrefab
- SpawnEntityPrefabLocal

### Why is this needed?
The base game according to BI devs has intentionally no event raises for when IEntities are created, or else the world load process would become way too slow. But for some of the scripted object creation, we will want different features to be notified if a new object is created. Often times this is solvable through adding a component onto them, but if we want to spawn prefabs that we do not want to override this would be a neat helper utility.

### How to use
```cs
void SpawnObject()
{
    EntitySpawnParams params();
    params.Transform[3] = "111.67 4.49 128.93";
    EL_ObjectManager.Event_OnEntityCreated.Insert(OnCreated);
    EL_ObjectManager.SpawnEntityPrefab(Resource.Load("<some-prefab>"), GetGame().GetWorld(), params);
}

void OnCreated(IEntity entityCreated)
{
    Print(entityCreated);
}
```
