### PR TITLE
Add feature/processing

### DIFF
--- a/src/Prefabs/Items/Drinks/Apple_Juice.et
+++ b/src/Prefabs/Items/Drinks/Apple_Juice.et
@@ -1,0 +1,19 @@
+GenericEntity : "{C95E11C60810F432}Prefabs/Items/Core/Item_Base.et" {
+ ID "508AB2013EEE1E00"
+ components {
+  InventoryItemComponent "{5222EB4D0C73006B}" {
+   Attributes SCR_ItemAttributeCollection "{5222EB4D0A2B466B}" {
+    ItemDisplayName UIInfo "{5222EB4D07D865FA}" {
+     Name "Apple Juice"
+    }
+    ItemPhysAttributes ItemPhysicalAttributes PhysicalAttributes {
+     DimensionScaler 0.01
+    }
+   }
+  }
+  MeshObject "{598F21A81E1F41BF}" {
+   Object "{240D853DBB045D05}Assets/Props/Civilian/BeerBottle_01/BeerBottle_01.xob"
+  }
+ }
+ coords 110.025 0.917 134.781
+}

--- a/src/Prefabs/Items/Drinks/Apple_Juice.et.meta
+++ b/src/Prefabs/Items/Drinks/Apple_Juice.et.meta
@@ -1,0 +1,15 @@
+MetaFileClass {
+ Name "{1DBD99E6347DE1AD}Prefabs/Items/Drinks/Apple_Juice.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/src/Prefabs/Processor/Apple_Processor.et
+++ b/src/Prefabs/Processor/Apple_Processor.et
@@ -1,0 +1,21 @@
+GenericEntity : "{8594DC1E8A135607}Prefabs/Processor/EL_Processor_Base.et" {
+ ID "598F21A86EB5B48E"
+ components {
+  MeshObject "{598F21A867C4015C}" {
+   Object "{8CCFA9079E967BB2}Assets/Props/Commercial/CoffeeGrinderShop_01/CoffeeGrinderShop_01.xob"
+  }
+  ActionsManagerComponent "{598F21A8710B89C1}" {
+   additionalActions {
+    EL_ProcessAction "{598F21A877BE6DEE}" {
+     m_PrefabToInput "{C9D661E5B0714711}Prefabs/Items/Food/Apple.et"
+     m_InputAmount 3
+     m_PrefabToOutput "{1DBD99E6347DE1AD}Prefabs/Items/Drinks/Apple_Juice.et"
+    }
+   }
+  }
+  RplComponent "{598F21A8E443044C}" {
+  }
+ }
+ coords 109.747 0.917 134.929
+ angleY 150
+}

--- a/src/Prefabs/Processor/Apple_Processor.et.meta
+++ b/src/Prefabs/Processor/Apple_Processor.et.meta
@@ -1,0 +1,15 @@
+MetaFileClass {
+ Name "{1DD3BF6A1A249CDE}Prefabs/Processor/Apple_Processor.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/src/Prefabs/Processor/EL_Processor_Base.et
+++ b/src/Prefabs/Processor/EL_Processor_Base.et
@@ -1,0 +1,28 @@
+GenericEntity {
+ ID "598F21A86EB5B48E"
+ components {
+  MeshObject "{598F21A867C4015C}" {
+  }
+  RigidBody "{598F21A88C41A341}" {
+   ModelGeometry 1
+   Static 1
+  }
+  ActionsManagerComponent "{598F21A8710B89C1}" {
+   ActionContexts {
+    UserActionContext "{598F21A871DA7304}" {
+     ContextName "default"
+     Position PointInfo "{598F21A875320722}" {
+     }
+    }
+   }
+   additionalActions {
+    EL_ProcessAction "{598F21A877BE6DEE}" {
+     ParentContextList {
+      "default"
+     }
+    }
+   }
+  }
+ }
+ coords 110.026 0.917 134.829
+}

--- a/src/Prefabs/Processor/EL_Processor_Base.et.meta
+++ b/src/Prefabs/Processor/EL_Processor_Base.et.meta
@@ -1,0 +1,15 @@
+MetaFileClass {
+ Name "{8594DC1E8A135607}Prefabs/Processor/EL_Processor_Base.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/src/Scripts/Game/Features/Processing/EL_ProcessAction.c
+++ b/src/Scripts/Game/Features/Processing/EL_ProcessAction.c
@@ -17,7 +17,7 @@ class EL_ProcessAction : ScriptedUserAction
 	
 	private ref array<IEntity> m_FoundItems = {};
 	InventoryStorageManagerComponent m_InventoryManager;
-	private string usingInventory = "Player";
+	private string usingInventory;
 	
 	//------------------------------------------------------------------------------------------------
 	override void PerformAction(IEntity pOwnerEntity, IEntity pUserEntity)

--- a/src/Scripts/Game/Features/Processing/EL_ProcessAction.c
+++ b/src/Scripts/Game/Features/Processing/EL_ProcessAction.c
@@ -1,0 +1,95 @@
+class EL_ProcessAction : ScriptedUserAction
+{
+	[Attribute(defvalue: "", uiwidget: UIWidgets.Auto, desc: "Output amount per process", category: "Spawn Area")]
+	private string m_ReciepeName;
+	
+	[Attribute(defvalue: "", uiwidget: UIWidgets.ResourcePickerThumbnail, desc: "Prefab to Spawn", "et", category: "Spawn Area")]
+	ResourceName m_PrefabToInput;
+	
+	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "Input amount per process", category: "Spawn Area")]
+	private int m_InputAmount;
+	
+	[Attribute(defvalue: "", uiwidget: UIWidgets.ResourcePickerThumbnail, desc: "Prefab to Spawn", "et", category: "Spawn Area")]
+	ResourceName m_PrefabToOutput;		
+	
+	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "Output amount per process", category: "Spawn Area")]
+	private int m_OutputAmount;
+	
+	private ref array<IEntity> m_FoundItems = {};
+	InventoryStorageManagerComponent m_InventoryManager;
+	private string usingInventory = "Player";
+	
+	//------------------------------------------------------------------------------------------------
+	override void PerformAction(IEntity pOwnerEntity, IEntity pUserEntity)
+	{
+		for (int i = 0; i < m_InputAmount; i++) 
+		{
+			m_InventoryManager.TryDeleteItem(m_FoundItems.Get(i));
+		}
+		for (int i = 0; i < m_OutputAmount; i++) 
+		{
+			m_InventoryManager.TrySpawnPrefabToStorage(m_PrefabToOutput);
+		}
+	}
+
+	//------------------------------------------------------------------------------------------------
+	override bool GetActionNameScript(out string outName)
+	{
+		outName = string.Format("Make %1 via %2", m_ReciepeName, usingInventory);
+		return true;
+	}
+	//------------------------------------------------------------------------------------------------
+	override bool CanBePerformedScript(IEntity user)
+ 	{
+		
+		//Find near vehicle inventory items and check if they fit this reciepe.
+		SetCannotPerformReason("Cant find items");
+		
+		//Check player inv.
+		usingInventory = "Backpack";
+		m_InventoryManager =  InventoryStorageManagerComponent.Cast(user.FindComponent(SCR_InventoryStorageManagerComponent));
+		GetAllInputItems(m_InventoryManager);
+			
+		if (m_FoundItems.Count() >= m_InputAmount)
+			return true;	
+		
+		//Check vehicle inv.
+		usingInventory = "Trunk";
+		GetGame().GetWorld().QueryEntitiesBySphere(GetOwner().GetOrigin(), 10, ContinueSearch, FilterVehicles, EQueryEntitiesFlags.ALL);
+		
+		return (m_FoundItems.Count() >= m_InputAmount);
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	//! TODO Only search owned vehicles.
+	private bool ContinueSearch(IEntity ent)
+	{
+		m_InventoryManager = InventoryStorageManagerComponent.Cast(ent.FindComponent(SCR_VehicleInventoryStorageManagerComponent));
+		GetAllInputItems(m_InventoryManager);
+		
+		return (m_FoundItems.Count() >= m_InputAmount);
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	bool FilterVehicles(IEntity ent) 
+	{
+		return (ent.Type() == Vehicle);
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	private void GetAllInputItems(notnull InventoryStorageManagerComponent inventory)
+	{
+		m_FoundItems.Clear();
+		array<IEntity> items = {};
+		inventory.GetItems(items);
+		
+		//Check if item in reciepe
+		foreach (IEntity item : items)
+		{
+			if (item.GetPrefabData().GetPrefabName() == m_PrefabToInput)
+			{
+				m_FoundItems.Insert(item);
+			}
+		}
+	}
+}

--- a/src/Scripts/Game/Features/Processing/EL_ProcessAction.c
+++ b/src/Scripts/Game/Features/Processing/EL_ProcessAction.c
@@ -1,22 +1,22 @@
 class EL_ProcessAction : ScriptedUserAction
 {
-	[Attribute(defvalue: "", uiwidget: UIWidgets.Auto, desc: "Output amount per process", category: "Spawn Area")]
-	private string m_ReciepeName;
+	[Attribute(defvalue: "", uiwidget: UIWidgets.Auto, desc: "Recipe name to show on action")]
+	private string m_RecipeName;
 	
-	[Attribute(defvalue: "", uiwidget: UIWidgets.ResourcePickerThumbnail, desc: "Prefab to Spawn", "et", category: "Spawn Area")]
+	[Attribute(defvalue: "", uiwidget: UIWidgets.ResourcePickerThumbnail, desc: "Prefab to Input", "et")]
 	ResourceName m_PrefabToInput;
 	
-	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "Input amount per process", category: "Spawn Area")]
+	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "Input amount per process")]
 	private int m_InputAmount;
 	
-	[Attribute(defvalue: "", uiwidget: UIWidgets.ResourcePickerThumbnail, desc: "Prefab to Spawn", "et", category: "Spawn Area")]
+	[Attribute(defvalue: "", uiwidget: UIWidgets.ResourcePickerThumbnail, desc: "Prefab to Output", "et")]
 	ResourceName m_PrefabToOutput;		
 	
-	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "Output amount per process", category: "Spawn Area")]
+	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "Output amount per process")]
 	private int m_OutputAmount;
 	
 	private ref array<IEntity> m_FoundItems = {};
-	InventoryStorageManagerComponent m_InventoryManager;
+	private InventoryStorageManagerComponent m_InventoryManager;
 	private string usingInventory;
 	
 	//------------------------------------------------------------------------------------------------
@@ -35,7 +35,7 @@ class EL_ProcessAction : ScriptedUserAction
 	//------------------------------------------------------------------------------------------------
 	override bool GetActionNameScript(out string outName)
 	{
-		outName = string.Format("Make %1 via %2", m_ReciepeName, usingInventory);
+		outName = string.Format("Make %1 via %2", m_RecipeName, usingInventory);
 		return true;
 	}
 	//------------------------------------------------------------------------------------------------
@@ -83,7 +83,7 @@ class EL_ProcessAction : ScriptedUserAction
 		array<IEntity> items = {};
 		inventory.GetItems(items);
 		
-		//Check if item in reciepe
+		//Check if item in recipe
 		foreach (IEntity item : items)
 		{
 			if (item.GetPrefabData().GetPrefabName() == m_PrefabToInput)

--- a/src/Worlds/DebugWorld/DebugWorld_AppleChain.layer
+++ b/src/Worlds/DebugWorld/DebugWorld_AppleChain.layer
@@ -457,6 +457,28 @@ $grp GenericEntity {
     coords -0.023 0.001 0.87
     angleY 171.533
    }
+   GenericEntity : "{1DD3BF6A1A249CDE}Prefabs/Processor/Apple_Processor.et" {
+    components {
+     ActionsManagerComponent "{598F21A8710B89C1}" {
+      ActionContexts {
+       UserActionContext "{598F21A871DA7304}" {
+        Position PointInfo "{598F21A875320722}" {
+         Offset 0 0.3718 0.1281
+        }
+        Radius 1
+       }
+      }
+      additionalActions {
+       EL_ProcessAction "{598F21A877BE6DEE}" {
+        Duration 2
+        m_ReciepeName "Apple Juice"
+       }
+      }
+     }
+    }
+    coords -2.457 0.917 -0.707
+    angleY 165
+   }
    $grp GenericEntity : "{622F9989DDC4865B}PrefabLibrary/Props/Civilian/Recreation/TableRecreation_01.et" {
     {
      coords 0.147 0.019 -0.144
@@ -513,8 +535,79 @@ $grp GenericEntity {
    }
   }
  }
+ AppleTradeContainer3 {
+  components {
+   EL_RestrictedInventoryStorageComponent "{59693C53BBA0FC99}" {
+    Attributes SCR_ItemAttributeCollection "{59693C53B153D96B}" {
+     ItemDisplayName UIInfo "{59693C53AAB06F2D}" {
+      Name "Apple Juice Trade"
+      Description "Trade apple juice for ammo"
+     }
+     ItemPhysAttributes ItemPhysicalAttributes "{59693C53A3873124}" {
+     }
+     CustomAttributes {
+      PreviewRenderAttributes "{59693C53D4D18183}" {
+       CameraOrbitAngles 330 30 0
+       CameraDistanceToItem 1
+      }
+     }
+     CommonItemType "NONE"
+     m_Size SLOT_3x3
+     m_SlotType SLOT_ANY
+    }
+    m_fMaxWeight 1000
+    m_TradablePrefabs {
+     "{1DBD99E6347DE1AD}Prefabs/Items/Drinks/Apple_Juice.et"
+    }
+   }
+   EL_TraderManagerComponent "{59693C53B6A5EFC0}" {
+    m_ItemToReceive "{1DBD99E6347DE1AD}Prefabs/Items/Drinks/Apple_Juice.et"
+    m_ItemToGive "{9C05543A503DB80E}Prefabs/Weapons/Magazines/Magazine_9x19_M9_15rnd_Ball.et"
+   }
+   MeshObject "{59670CE9C98E5BAF}" {
+    Object "{55991E1823C60AB3}Assets/Props/Crates/Crate_01.xob"
+   }
+   RigidBody "{59670CE9C98E5B27}" {
+    Mass 10
+    ModelGeometry 1
+    Static 1
+   }
+   ActionsManagerComponent "{59670CE9C98E5814}" {
+    ActionContexts {
+     UserActionContext "{59670CE9C98E5829}" {
+      ContextName "default"
+      Position PointInfo "{59670CE9C98E582A}" {
+       Offset 0 0.0873 0
+      }
+      Radius 1.5
+     }
+    }
+    additionalActions {
+     EL_OpenTraderAction "{59670CE9FBF3C749}" {
+      ParentContextList {
+       "default"
+      }
+      UIInfo UIInfo "{59670CE9F9F9794D}" {
+       Name "Trade Apple Juice"
+       Description "Trade apple juice for ammo"
+      }
+     }
+    }
+   }
+   RplComponent "{59670CE9C98E581E}" {
+    Enabled 1
+   }
+  }
+  coords 109.216 0.916 135.057
+  angleY -14.907
+  Flags 1027
+ }
 }
 Tree AppleGatherTree : "{1C6F9AD2669C17F9}Prefabs/Vegetation/Tree/t_malus_domestica_2s.et" {
  coords 112.51 0.002 135.664
  angleY 86.566
+}
+GenericEntity : "{622F9989DDC4865B}PrefabLibrary/Props/Civilian/Recreation/TableRecreation_01.et" {
+ coords 108.846 0.018 135.126
+ angleY 82.104
 }


### PR DESCRIPTION
Adds 
+ Base Processor prefab
+ Process Action (Direct add / remove from inventory)
+ Apple juice processor prefab
+ Apple juice item
+ Apple juice trader

Works with nearest Vehicle and Player inventory.
Uses placeholder models from base game.

Future plan is to filter owned vehicles.


![image](https://user-images.githubusercontent.com/45827986/172585089-9ea00dd5-b895-4918-8b9e-6db3c5110c4d.png)
