### PR TITLE
Add ClearDatabasePlugin

### DIFF
--- a/src/Scripts/WorkbenchGame/WorldEditor/EL_ClearDatabasePlugin.c
+++ b/src/Scripts/WorkbenchGame/WorldEditor/EL_ClearDatabasePlugin.c
@@ -13,6 +13,7 @@ class EL_ClearDatabasePlugin: WorkbenchPlugin
 	override void Run()
 	{
 		System.FindFiles(DeleteFileCallback, DB_BASE_DIR, ".json");
+		System.FindFiles(DeleteFileCallback, DB_BASE_DIR, ".bin");
 		System.FindFiles(DeleteFileCallback, DB_BASE_DIR, string.Empty);
 		Print("-- DATABASE CLEARED --", LogLevel.WARNING);
 	}

--- a/src/Scripts/WorkbenchGame/WorldEditor/EL_ClearDatabasePlugin.c
+++ b/src/Scripts/WorkbenchGame/WorldEditor/EL_ClearDatabasePlugin.c
@@ -1,0 +1,19 @@
+[WorkbenchPluginAttribute("Clear Database", "Deletes the .db folder!", "", "", {"WorldEditor", "ResourceManager"}, "", 0xf1c0)]
+class EL_ClearDatabasePlugin: WorkbenchPlugin
+{
+	const string DB_BASE_DIR = "$profile:/.db";
+
+	//------------------------------------------------------------------------------------------------
+	void DeleteFileCallback(string path, FileAttribute attributes)
+	{
+		FileIO.DeleteFile(path);
+	}
+
+	//------------------------------------------------------------------------------------------------
+	override void Run()
+	{
+		System.FindFiles(DeleteFileCallback, DB_BASE_DIR, ".json");
+		System.FindFiles(DeleteFileCallback, DB_BASE_DIR, string.Empty);
+		Print("-- DATABASE CLEARED --", LogLevel.WARNING);
+	}
+};


### PR DESCRIPTION
Adds a plugin button to clear all files and folders in the .db folder.
Available in the main Enfusion Workbench and World Editor Window
![image](https://user-images.githubusercontent.com/45827986/188905171-c8e2f46a-fdee-422c-bc20-bbb15f2bb93e.png)
