### PR TITLE
Add `Attach()` to `EL_PersistenceComponent`

### DIFF
--- a/src/Scripts/Game/Core/Persistence/EL_PersistenceComponent.c
+++ b/src/Scripts/Game/Core/Persistence/EL_PersistenceComponent.c
@@ -243,10 +243,17 @@ class EL_PersistenceComponent : ScriptComponent
 	}
 
 	//------------------------------------------------------------------------------------------------
-	//! Mark the entity as detached from persistence, to ignore Save, Load and Delete operations. Can not be undone. Used primarily to handle removal of the instance externally.
+	//! Mark the entity as detached from persistence, to ignore Save, Load and Delete operations. Used primarily to handle removal of the instance externally.
 	void Detach()
 	{
 		m_bDetatched = true;
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	//! Mark the entity as attached to persistence, to respect Save, Load and Delete operations.
+	void Attach()
+	{
+		m_bDetatched = false;
 	}
 
 	//------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I'm currently building a DayZ-esque survivor mod that depends on EveronLife for the persistence (which btw is awesome). Part of my loot system needs to be able to detach/re-attach entities from persistence. I think the `Detach()` method would work fine for this but of course there's no `Attach()` method to then flip the persistence back on. This might be a nonsensical change/thing to do so please educate me if that's the case 👍🏻 