### PR TITLE
Change nametag default to off

### DIFF
--- a/docs/feature/character/nametag.md
+++ b/docs/feature/character/nametag.md
@@ -1,0 +1,2 @@
+# Enable Nametags over Players
+In the `EL_GameModeRoleplay` Entity enable the `SCR_NametagConfigComponent`.

--- a/src/Prefabs/MP/Modes/Roleplay/GameMode_Roleplay.et
+++ b/src/Prefabs/MP/Modes/Roleplay/GameMode_Roleplay.et
@@ -56,6 +56,9 @@ EL_GameModeRoleplay {
   ScriptedChatEntity ScriptedChatEntity : "{F69BC912AC8236F9}Prefabs/MP/ScriptedChatEntity.et" {
    ID "59751433747F9C02"
   }
+  SCR_GarbageManager GarbageManager {
+   ID "59751433747F9391"
+  }
   SCR_MPDestructionManager MPDestructionManager : "{9BB369F2803C6F71}Prefabs/MP/MPDestructionManager.et" {
    ID "59751433747F2879"
   }

--- a/src/Prefabs/MP/Modes/Roleplay/GameMode_Roleplay.et
+++ b/src/Prefabs/MP/Modes/Roleplay/GameMode_Roleplay.et
@@ -36,6 +36,7 @@ EL_GameModeRoleplay {
   SCR_HintManagerComponent "{59E8CC4E575D1802}" {
   }
   SCR_NametagConfigComponent "{597514328498E41D}" {
+   Enabled 0
    m_sConfigPath "{8547E1B142411624}Configs/NameTags/NametagRoleplay.conf"
   }
   RplComponent "{597514327E500A0C}" {
@@ -54,9 +55,6 @@ EL_GameModeRoleplay {
   }
   ScriptedChatEntity ScriptedChatEntity : "{F69BC912AC8236F9}Prefabs/MP/ScriptedChatEntity.et" {
    ID "59751433747F9C02"
-  }
-  SCR_GarbageManager GarbageManager {
-   ID "59751433747F9391"
   }
   SCR_MPDestructionManager MPDestructionManager : "{9BB369F2803C6F71}Prefabs/MP/MPDestructionManager.et" {
    ID "59751433747F2879"


### PR DESCRIPTION
Based on https://github.com/EveronLife/EveronLife/discussions/151 nametags should be off by default.

I guess the `SCR_GarbageManager` component was deleted in a recent patch, cant add it back

