### PR TITLE
Update custom_server.md

### DIFF
--- a/docs/custom_server.md
+++ b/docs/custom_server.md
@@ -116,13 +116,16 @@ Go into the installation directory of your dedicated server e.g. `C:\Program Fil
 	"bindPort": 2001,
 	"publicAddress": "",
 	"publicPort": 2001,
+	"a2s": {
+		"address": "",
+		"port": 17777
+	},
 	"game": {
 		"name": "Roleplay - MyCustomServer",
 		"password": "",
 		"passwordAdmin": "roleplayftw",
 		"scenarioId": "{5C552F6B07B10383}Missions/MyCustomServer.conf", <----- Mission config path mentioned in the previous step
-		"playerCountLimit": 32,
-		"autoJoinable": true,
+		"maxPlayers": 64,
 		"visible": true,
 		"gameProperties": {
 			"serverMaxViewDistance": 2500,
@@ -139,9 +142,7 @@ Go into the installation directory of your dedicated server e.g. `C:\Program Fil
 				"version": "0.0.1" <---------------------- Your mod version here (likely to be 0.0.1 at first if you followed this guide.
 			}
 		]
-	},
-	"a2sQueryEnabled": true,
-	"steamQueryPort": 17777
+	}
 }
 ```
 Make sure to remove the helper arrows from the file before saving.


### PR DESCRIPTION
**Compatibility changes**

- `playerCountLimit` (v0.9.8.73) to [maxPlayers](https://community.bistudio.com/wiki/Arma_Reforger:Server_Config#maxPlayers)
- `a2sQueryEnabled ` and `steamQueryPort`  (v0.9.9) to [a2s adress and port](https://community.bistudio.com/wiki/Arma_Reforger:Server_Config#a2s_2)
- Remove `autoJoinable` (Console shows the following error, nowhere found anything about autoJoinable. If you find something, please improve it.)
 ```
 09:33:55.521    BACKEND   (E): Param "#/game/autoJoinable" is not allowed and must be removed.
09:33:55.521    BACKEND   (E): Reference in schema: "#/properties/game"
```